### PR TITLE
Test snappy failure on Python 3.11

### DIFF
--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -ex
           python -m pip install --upgrade 'pip<23' wheel
-          python -m pip install --upgrade .
+          python -m pip install --upgrade .[all]
           python -m pip install pytest==7.2.1 pytest_codeblocks==0.16.1
       - name: Run checks
         run: |


### PR DESCRIPTION
Test snappy failure on Python 3.11